### PR TITLE
small fixes to err handling and dhall type handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func loadResource(rootDir string, filename string) (*Resource, error) {
 	res.Source = filename
 	err = decoder.Decode(&res.Contents)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode yaml file: %s: %v", filename, err)
 	}
 
 	kind, ok := res.Contents["kind"].(string)
@@ -385,12 +385,16 @@ func composeSimplifiedDhallType(yamlBytes []byte) (string, error) {
 
 	dhallTypeBytes, err := dhallRecordToType(ctx, yamlBytes)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to derive dhall type from record: %v", err)
+	}
+
+	if !strengthen {
+		return string(dhallTypeBytes), nil
 	}
 
 	rt, err := parseRecordType(bytes.NewReader(dhallTypeBytes))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to parse dhall type: %v", err)
 	}
 
 	transformRecordType(rt)


### PR DESCRIPTION
don't parse type record when not using --strengthenSchema