### PR TITLE
ci: remove deprecated set-env statements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
       - name: '[setup] Install asdf'
-        uses: 'asdf-vm/actions/setup@v1.0.0'
+        uses: 'asdf-vm/actions/setup@v1.0.1'
       - name: '[setup] Install asdf plugins'
         run: './ci/asdf-add-plugins.sh'
       - name: '[setup] Install asdf .tool-versions'
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
       - name: '[setup] Install asdf'
-        uses: 'asdf-vm/actions/setup@v1.0.0'
+        uses: 'asdf-vm/actions/setup@v1.0.1'
       - name: '[setup] Install asdf plugins'
         run: './ci/asdf-add-plugins.sh'
       - name: '[setup] Install asdf .tool-versions'
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
       - name: '[setup] Install asdf'
-        uses: 'asdf-vm/actions/setup@v1.0.0'
+        uses: 'asdf-vm/actions/setup@v1.0.1'
       - name: '[setup] Install asdf plugins'
         run: './ci/asdf-add-plugins.sh'
       - name: '[setup] Install asdf .tool-versions'
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
       - name: '[setup] Install asdf'
-        uses: 'asdf-vm/actions/setup@v1.0.0'
+        uses: 'asdf-vm/actions/setup@v1.0.1'
       - name: '[setup] Install asdf plugins'
         run: './ci/asdf-add-plugins.sh'
       - name: '[setup] Install asdf .tool-versions'
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
       - name: '[setup] Install asdf'
-        uses: 'asdf-vm/actions/setup@v1.0.0'
+        uses: 'asdf-vm/actions/setup@v1.0.1'
       - name: '[setup] Install asdf plugins'
         run: './ci/asdf-add-plugins.sh'
       - name: '[setup] Install asdf .tool-versions'
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
       - name: '[setup] Install asdf'
-        uses: 'asdf-vm/actions/setup@v1.0.0'
+        uses: 'asdf-vm/actions/setup@v1.0.1'
       - name: '[setup] Install asdf plugins'
         run: './ci/asdf-add-plugins.sh'
       - name: '[setup] Install asdf .tool-versions'
@@ -114,7 +114,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
       - name: '[setup] Install asdf'
-        uses: 'asdf-vm/actions/setup@v1.0.0'
+        uses: 'asdf-vm/actions/setup@v1.0.1'
       - name: '[setup] Install asdf plugins'
         run: './ci/asdf-add-plugins.sh'
       - name: '[setup] Install asdf .tool-versions'
@@ -129,7 +129,7 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
       - name: '[setup] Install asdf'
-        uses: 'asdf-vm/actions/setup@v1.0.0'
+        uses: 'asdf-vm/actions/setup@v1.0.1'
       - name: '[setup] Install asdf plugins'
         run: './ci/asdf-add-plugins.sh'
       - name: '[setup] Install asdf .tool-versions'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,9 +63,9 @@ jobs:
       - name: '[setup] prepare go environment'
         run: './ci/asdf-setup-go.sh'
       - name: golangci-lint
-        uses: 'golangci/golangci-lint-action@v1'
+        uses: 'golangci/golangci-lint-action@v2.3.0'
         with:
-          version: v1.30
+          version: v1.32.2
   goreleaser:
     name: goreleaser
     runs-on: ubuntu-latest

--- a/ci/asdf-setup-go.sh
+++ b/ci/asdf-setup-go.sh
@@ -5,5 +5,5 @@ set -euxo pipefail
 
 ASDF_GOLANG_DIRECTORY="$(asdf where golang)/go"
 
-# https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-echo "::set-env name=GOROOT::${ASDF_GOLANG_DIRECTORY}"
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files
+echo "GOROOT=${ASDF_GOLANG_DIRECTORY}" >>"$GITHUB_ENV"

--- a/ci/dhall/jobs/golangci-lint.dhall
+++ b/ci/dhall/jobs/golangci-lint.dhall
@@ -12,8 +12,8 @@ in  Job::{
           SetupSteps
         # [ GitHubActions.Step::{
             , name = Some "golangci-lint"
-            , uses = Some "golangci/golangci-lint-action@v1"
-            , `with` = Some (toMap { version = "v1.30" })
+            , uses = Some "golangci/golangci-lint-action@v2.3.0"
+            , `with` = Some (toMap { version = "v1.32.2" })
             }
           ]
     }

--- a/ci/dhall/setup.dhall
+++ b/ci/dhall/setup.dhall
@@ -9,7 +9,7 @@ let Checkout =
 let ASDFSteps =
       [ GitHubActions.Step::{
         , name = Some "[setup] Install asdf"
-        , uses = Some "asdf-vm/actions/setup@v1.0.0"
+        , uses = Some "asdf-vm/actions/setup@v1.0.1"
         }
       , GitHubActions.Step::{
         , name = Some "[setup] Install asdf plugins"


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/