### PR TITLE
correct api tag in metadata patch for statefulset volumeclaimtemplate

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 brews:
-  - github:
+  - tap:
       owner: sourcegraph
       name: homebrew-ds-to-dhall
     folder: Formula

--- a/main.go
+++ b/main.go
@@ -307,7 +307,7 @@ func loadResource(rootDir string, filename string) (*Resource, error) {
 			if !ok {
 				return nil, fmt.Errorf("resource %s is missing volumeClaimTemplate section", filename)
 			}
-			vct["apiVersion"] = "apps/v1"
+			vct["apiVersion"] = "v1"
 			vct["kind"] = "PersistentVolumeClaim"
 		}
 	} else if res.Kind == "CronJob" {


### PR DESCRIPTION
revealed while doing

```
dhall diff '(./src/k8s/pipeline.dhall).grafana' '(./deploy-sourcegraph.dhall).grafana' 
```