### PR TITLE
support -h and --help flags (needed by asdf plugin)

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,8 +57,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	if os.Args[1] == "help" {
-		if len(os.Args) == 2 {
+	if os.Args[1] == "help" || os.Args[1] == "--help" || os.Args[1] == "-h" {
+		if len(os.Args) == 2 || os.Args[1] == "--help" || os.Args[1] == "-h" {
+			fmt.Println("ds-to-dhall <command>")
+			fmt.Println("available commands:")
 			w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, ' ', 0)
 
 			for cmdName := range cmds {

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 		cmd([]string{"-h"})
 	}
 
-	if os.Args[1] == "version" {
+	if os.Args[1] == "version" || os.Args[1] == "--version" || os.Args[1] == "-v" {
 		output := versionString(version, commit, date)
 		fmt.Fprintln(os.Stderr, output)
 		os.Exit(0)


### PR DESCRIPTION
even though the binary is now with sub-commands and has the help sub-command, we need these two flags for the asdf plugin