### PR TITLE
dhall2ds include stdout/err when command fails

### DIFF
--- a/dhall2ds/dhall2ds.go
+++ b/dhall2ds/dhall2ds.go
@@ -153,7 +153,6 @@ type cmdErr struct {
 }
 
 func (c *cmdErr) Error() string {
-
 	return strings.Join([]string{
 		fmt.Sprintf("command: %q", c.command),
 		fmt.Sprintf("standard out:\n%s", c.stdOut),

--- a/dhall2ds/dhall2ds.go
+++ b/dhall2ds/dhall2ds.go
@@ -130,6 +130,7 @@ func dhallToYAML(ctx context.Context, dhallFile string) (map[string]interface{},
 
 		command := append([]string{bin}, args...)
 		return nil, &cmdErr{
+			err:     err,
 			command: strings.Join(command, " "),
 			stdOut:  outBuf.String(),
 			stdErr:  errBuf.String(),
@@ -150,10 +151,12 @@ type cmdErr struct {
 	command string
 	stdOut  string
 	stdErr  string
+	err     error
 }
 
 func (c *cmdErr) Error() string {
 	return strings.Join([]string{
+		fmt.Sprintf("error: %s", c.err),
 		fmt.Sprintf("command: %q", c.command),
 		fmt.Sprintf("standard out:\n%s", c.stdOut),
 		fmt.Sprintf("standard err:\n%s", c.stdErr),

--- a/dhall2ds/dhall2ds.go
+++ b/dhall2ds/dhall2ds.go
@@ -100,7 +100,7 @@ func Main(args []string) {
 
 	componentTree, err := dhallToYAML(ctx, flagSet.Arg(0))
 	if err != nil {
-		if e, ok := err.(*cmdErr); ok {
+		if e, ok := err.(*commandError); ok {
 			// bypass log15 to have more control over what the error output looks like
 			// (newlines)
 			log.Fatalf("failed to execute dhall-to-yaml, err:\n%s", e)
@@ -136,7 +136,7 @@ func dhallToYAML(ctx context.Context, dhallFile string) (map[string]interface{},
 	if err != nil {
 		command := append([]string{bin}, args...)
 
-		return nil, &cmdErr{
+		return nil, &commandError{
 			err:     err,
 			command: strings.Join(command, " "),
 			stdOut:  outBuf.String(),
@@ -154,14 +154,14 @@ func dhallToYAML(ctx context.Context, dhallFile string) (map[string]interface{},
 	return rv, nil
 }
 
-type cmdErr struct {
+type commandError struct {
 	command string
 	stdOut  string
 	stdErr  string
 	err     error
 }
 
-func (c *cmdErr) Error() string {
+func (c *commandError) Error() string {
 	return strings.Join([]string{
 		fmt.Sprintf("error: %s", c.err),
 		fmt.Sprintf("command: %q", c.command),

--- a/dhall2ds/dhall2ds.go
+++ b/dhall2ds/dhall2ds.go
@@ -134,13 +134,14 @@ func dhallToYAML(ctx context.Context, dhallFile string) (map[string]interface{},
 
 	err := cmd.Run()
 	if err != nil {
-		command := append([]string{bin}, args...)
-
 		return nil, &commandError{
-			err:     err,
-			command: strings.Join(command, " "),
-			stdOut:  outBuf.String(),
-			stdErr:  errBuf.String(),
+			err: err,
+
+			name: bin,
+			args: args,
+
+			stdOut: outBuf.String(),
+			stdErr: errBuf.String(),
 		}
 	}
 
@@ -155,16 +156,21 @@ func dhallToYAML(ctx context.Context, dhallFile string) (map[string]interface{},
 }
 
 type commandError struct {
-	command string
-	stdOut  string
-	stdErr  string
-	err     error
+	err error
+
+	name string
+	args []string
+
+	stdOut string
+	stdErr string
 }
 
 func (c *commandError) Error() string {
+	command := strings.Join(append([]string{c.name}, c.args...), " ")
+
 	return strings.Join([]string{
 		fmt.Sprintf("error: %s", c.err),
-		fmt.Sprintf("command: %q", c.command),
+		fmt.Sprintf("command: %q", command),
 		fmt.Sprintf("standard output:\n%s", c.stdOut),
 		fmt.Sprintf("standard error:\n%s", c.stdErr),
 	}, "\n")

--- a/dhall2ds/dhall2ds.go
+++ b/dhall2ds/dhall2ds.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -99,6 +100,12 @@ func Main(args []string) {
 
 	componentTree, err := dhallToYAML(ctx, flagSet.Arg(0))
 	if err != nil {
+		if e, ok := err.(*cmdErr); ok {
+			// bypass log15 to have more control over what the error output looks like
+			// (newlines)
+			log.Fatalf("failed to execute dhall-to-yaml, err:\n%s", e)
+		}
+
 		logFatal("failed to execute dhall-to-yaml", "error", err)
 	}
 
@@ -158,8 +165,8 @@ func (c *cmdErr) Error() string {
 	return strings.Join([]string{
 		fmt.Sprintf("error: %s", c.err),
 		fmt.Sprintf("command: %q", c.command),
-		fmt.Sprintf("standard out:\n%s", c.stdOut),
-		fmt.Sprintf("standard err:\n%s", c.stdErr),
+		fmt.Sprintf("standard output:\n%s", c.stdOut),
+		fmt.Sprintf("standard error:\n%s", c.stdErr),
 	}, "\n")
 }
 

--- a/dhall2ds/dhall2ds.go
+++ b/dhall2ds/dhall2ds.go
@@ -134,8 +134,8 @@ func dhallToYAML(ctx context.Context, dhallFile string) (map[string]interface{},
 
 	err := cmd.Run()
 	if err != nil {
-
 		command := append([]string{bin}, args...)
+
 		return nil, &cmdErr{
 			err:     err,
 			command: strings.Join(command, " "),


### PR DESCRIPTION
Example output:

```
❯ ./main dhall2ds ci/dhall/setup.dhall --output wut | pbcopy                                                                                                                           15:39:34
2021/01/27 15:39:38 failed to execute dhall-to-yaml, err:
error: exit status 1
command: "dhall-to-yaml --file ci/dhall/setup.dhall"
standard output:

standard error:

Error: Cannot translate to JSON                                            
                                                                                
Explanation: Only primitive values, records, unions, ❰List❱s, and ❰Optional❱    
values can be translated from Dhall to JSON                                     
                                                                                
The following Dhall expression could not be translated to JSON:                 
                                                                                
↳ { defaults :
      Optional
        { run :
            Optional { shell : Optional Text, working-directory : Optional Text }
        }
  , env : Optional (List { mapKey : Text, mapValue : Text })
  , `if` : Optional Text
  , name : Optional Text
  , needs : Optional (List Text)
  , outputs : Optional (List { mapKey : Text, mapValue : Text })
  , runs-on :
      < custom : List Text
      | `macos-10.05`
      | macos-latest
      | self-hosted
      | `ubuntu-16.04`
      | `ubuntu-18.04`
      | ubuntu-latest
      | windows-2019
      | windows-latest
  ===============================================================================
        , run : Optional Text
        , shell : Optional Text
        , strategy :
            Optional
              { fail-fast : Optional Bool
              , matrix : List { mapKey : Text, mapValue : List Text }
              , max-parallel : Optional Natural
              }
        , uses : Optional Text
        , `with` : Optional (List { mapKey : Text, mapValue : Text })
        , working-directory : Optional Text
        }
  , strategy :
      Optional
        { fail-fast : Optional Bool
        , matrix : List { mapKey : Text, mapValue : List Text }
        , max-parallel : Optional Natural
        }
  , timeout-minutes : Optional Natural
  }
```