### PR TITLE
homebrew: add dhall dependencies

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,12 @@ brews:
     folder: Formula
     homepage: https://github.com/sourcegraph/ds-to-dhall
     description: CLI to translate deploy-sourcegraph YAML to Dhall
+    dependencies:
+      - name: dhall
+      - name: dhall-json
+      - name: dhall-yaml
+      - name: dhall-bash
+      - name: dhall-lsp-server
     test: |
       system "#{bin}/ds-to-dhall --help"
 builds:


### PR DESCRIPTION
Now we can just tell people to brew install this command, and everything else they need will come down with it.  

(dhall-lsp-server, dhall-bash, etc. aren't strictly necessary - but I thought that we might as well have them grab everything if it's the same command) 